### PR TITLE
auto: code-gen upgrade handler v18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
 DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
-E2E_UPGRADE_VERSION := "v14"
+E2E_UPGRADE_VERSION := "v18"
 
 
 GO_MAJOR_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/app/app.go
+++ b/app/app.go
@@ -46,6 +46,7 @@ import (
 	v12 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v12"
 	v13 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v13"
 	v14 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v14"
+	v18 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v18"
 	v3 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v3"
 	v4 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v4"
 	v5 "github.com/osmosis-labs/osmosis/v13/app/upgrades/v5"
@@ -92,7 +93,7 @@ var (
 
 	// _ sdksimapp.App = (*OsmosisApp)(nil)
 
-	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade}
+	Upgrades = []upgrades.Upgrade{v4.Upgrade, v5.Upgrade, v7.Upgrade, v9.Upgrade, v11.Upgrade, v12.Upgrade, v13.Upgrade, v14.Upgrade, v18.Upgrade}
 	Forks    = []upgrades.Fork{v3.Fork, v6.Fork, v8.Fork, v10.Fork}
 )
 

--- a/app/upgrades/v18/constants.go
+++ b/app/upgrades/v18/constants.go
@@ -1,0 +1,19 @@
+package v18
+
+import (
+	"github.com/osmosis-labs/osmosis/v13/app/upgrades"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the Osmosis v18 upgrade.
+const UpgradeName = "v18"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+    },
+}

--- a/app/upgrades/v18/upgrades.go
+++ b/app/upgrades/v18/upgrades.go
@@ -1,0 +1,21 @@
+package v18
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/osmosis-labs/osmosis/v13/app/keepers"
+	"github.com/osmosis-labs/osmosis/v13/app/upgrades"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bpm upgrades.BaseAppParamManager,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/tests/e2e/containers/config.go
+++ b/tests/e2e/containers/config.go
@@ -24,10 +24,10 @@ const (
 	// It should be uploaded to Docker Hub. OSMOSIS_E2E_SKIP_UPGRADE should be unset
 	// for this functionality to be used.
 	previousVersionOsmoRepository = "osmolabs/osmosis-dev"
-	previousVersionOsmoTag        = "13.1.0"
+	previousVersionOsmoTag        = "v17.0.0"
 	// Pre-upgrade repo/tag for osmosis initialization (this should be one version below upgradeVersion)
 	previousVersionInitRepository = "osmolabs/osmosis-e2e-init-chain"
-	previousVersionInitTag        = "v13.1.0"
+	previousVersionInitTag        = "v17.0.0"
 	// Hermes repo/version for relayer
 	relayerRepository = "osmolabs/hermes"
 	relayerTag        = "0.13.0"


### PR DESCRIPTION
Update report
- Created a new empty upgrade handler
- Increased E2E_UPGRADE_VERSION in Makefile by 1
- Bumps up e2e-init tags